### PR TITLE
Set MSRV to 1.67

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "csnmp"
 version = "0.6.0"
 edition = "2021"
+rust-version = "1.67"
 license = "CC0-1.0"
 description = "Community-based async (Tokio) SNMP client library"
 repository = "https://github.com/RavuAlHemio/csnmp"


### PR DESCRIPTION
Determined with cargo-msrv.

More specific, Rust 1.67 is required by deps: time, time-macros, time-core, powerfmt and deranged.